### PR TITLE
Fix outdated IRC section link

### DIFF
--- a/header.incl
+++ b/header.incl
@@ -83,7 +83,7 @@
   <br><br>
 
   <span style="font-size:smaller">IRC Channel:</span><br>
-  <a href="/docs/#irc">irc.oftc.net #llvm</a>
+  <a href="/docs/GettingInvolved.html#irc">irc.oftc.net #llvm</a>
 
   <br><br>
 


### PR DESCRIPTION
IRC section was split off somewhere between 9.0.0 and 9.0.1, this link has been stale since then