### PR TITLE
Update bug tracker to GitHub.

### DIFF
--- a/OpenProjects.html
+++ b/OpenProjects.html
@@ -1049,11 +1049,11 @@
   <p><b>Preparation resources:</b>
     <ul>
       <li>
-        <a href="https://bugs.llvm.org/show_bug.cgi?id=37728">PR37728</a> is a
+        <a href="https://llvm.org/PR37728">PR37728</a> is a
         meta-bug that collects several related issues of differing codegen.
       </li>
       <li>
-        <a href="https://bugs.llvm.org/show_bug.cgi?id=37240">PR37240</a> is a
+        <a href="https://llvm.org/PR37240">PR37240</a> is a
         bug discussing the CFI issue mentioned above.
       </li>
       <li>
@@ -2013,8 +2013,10 @@ or to suggest other projects to add to this page.
 </p>
 
 <p>The projects in this page are open-ended. More specific projects are
-filed as unassigned enhancements in the <a href="http://bugs.llvm.org/">
-LLVM bug tracker</a>. See the <a href="http://bugs.llvm.org/buglist.cgi?keywords_type=allwords&amp;keywords=&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=enhancement&amp;emailassigned_to1=1&amp;emailtype1=substring&amp;email1=unassigned">list of currently outstanding issues</a> if you wish to help improve LLVM.</p>
+filed as unassigned enhancements in the <a href="https://bugs.llvm.org/">
+LLVM bug tracker</a>. See the
+<a href="https://github.com/llvm/llvm-project/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee">list of currently outstanding issues</a>
+if you wish to help improve LLVM.</p>
 
 </div>
 
@@ -2114,9 +2116,8 @@ across the board.</p>
 <div class="www_text">
 
 <p>
-The <a href="http://bugs.llvm.org/">LLVM bug tracker</a> occasionally
-has <a
-  href="http://bugs.llvm.org/buglist.cgi?short_desc_type=allwordssubstr&amp;short_desc=&amp;long_desc_type=allwordssubstr&amp;long_desc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;keywords_type=allwords&amp;keywords=code-cleanup&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailassigned_to1=1&amp;emailtype1=substring&amp;email1=&amp;emailassigned_to2=1&amp;emailreporter2=1&amp;emailcc2=1&amp;emailtype2=substring&amp;email2=&amp;bugidtype=include&amp;bug_id=&amp;votes=&amp;changedin=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;order=Bug+Number&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=">"code-cleanup" bugs</a> filed in it.
+The <a href="https://bugs.llvm.org/">LLVM bug tracker</a> occasionally
+has <a href="https://github.com/llvm/llvm-project/labels/code-cleanup">"code-cleanup" bugs</a> filed in it.
 Taking one of these and fixing it is a good way to get your feet wet in the
 LLVM code and discover how some of its components work.  Some of these include
 some major IR redesign work, which is high-impact because it can simplify a lot
@@ -2135,7 +2136,8 @@ Some specific ones that would be great to have:
 
 <p>Additionally, there are performance improvements in LLVM that need to get
 fixed. These are marked with the <tt>slow-compile</tt> keyword. Use
-<a href="http://bugs.llvm.org/buglist.cgi?short_desc_type=allwordssubstr&amp;short_desc=&amp;long_desc_type=allwordssubstr&amp;long_desc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;keywords_type=allwords&amp;keywords=slow-compile&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailassigned_to1=1&amp;emailtype1=substring&amp;email1=&amp;emailassigned_to2=1&amp;emailreporter2=1&amp;emailcc2=1&amp;emailtype2=substring&amp;email2=&amp;bugidtype=include&amp;bug_id=&amp;votes=&amp;changedin=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;namedcmd=Bugs+I+Fixed&amp;newqueryname=&amp;order=Reuse+same+sort+as+last+time&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=">this Bugzilla query</a>
+<a href="https://github.com/llvm/llvm-project/issues?q=is%3Aopen+is%3Aissue+label%3Aslow-compile">
+this LLVM bug tracker query</a>
 to find them.</p>
 
 </div>
@@ -2201,7 +2203,7 @@ all the back-ends: CBE, llc, and lli.</p>
 href="/nightlytest/">test results</a> or on your own,
 where LLVM code generators do not produce optimal code or where another
 compiler produces better code.  Try to minimize the test case that demonstrates
-the issue.  Then, either <a href="http://bugs.llvm.org/">submit a
+the issue.  Then, either <a href="https://bugs.llvm.org/">submit a
 bug</a> with your testcase and the code that LLVM produces vs. the code that it
 <em>should</em> produce, or even better, see if you can improve the code
 generator and submit a patch.  The basic idea is that it's generally quite easy
@@ -2287,9 +2289,9 @@ what architecture is covered.</p>
 <li>Completely rewrite bugpoint.  In addition to being a mess, bugpoint suffers
 from a number of problems where it will "lose" a bug when reducing.  It should
 be rewritten from scratch to solve these and other problems.</li>
-<li><a href="http://bugs.llvm.org/show_bug.cgi?id=2116">Add support for
+<li><a href="https://llvm.org/PR2116">Add support for
 transactions to the PassManager</a> for improved bugpoint.</li>
-<li><a href="http://bugs.llvm.org/show_bug.cgi?id=539">Improve bugpoint to
+<li><a href="https://llvm.org/PR539">Improve bugpoint to
 support running tests in parallel on MP machines</a>.</li>
 <li>Add MC assembler/disassembler and JIT support to the SPARC port.</li>
 <li>Move more optimizations out of the <tt>-instcombine</tt> pass and into
@@ -2329,8 +2331,8 @@ improvements to LLVM core</a> are awaiting design and implementation.</p>
 <li><a href="http://nondot.org/sabre/LLVMNotes/DebugInfoImprovements.txt">Improvements
 for Debug Information Generation</a></li>
 <li><a href="/PR1269">EH support for non-call exceptions</a></li>
-<li>Many ideas for feature requests are stored in LLVM bugzilla.  Search<a
-  href="http://bugs.llvm.org/buglist.cgi?short_desc_type=allwordssubstr&amp;short_desc=&amp;long_desc_type=allwordssubstr&amp;long_desc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;keywords_type=allwords&amp;keywords=new-feature&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailassigned_to1=1&amp;emailtype1=substring&amp;email1=&amp;emailassigned_to2=1&amp;emailreporter2=1&amp;emailcc2=1&amp;emailtype2=substring&amp;email2=&amp;bugidtype=include&amp;bug_id=&amp;votes=&amp;changedin=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;namedcmd=All+PRs&amp;newqueryname=&amp;order=Bug+Number&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=">for bugs with a "new-feature" keyword</a>.</li>
+<li>Many ideas for feature requests are stored in LLVM bugzilla.  Search
+<a href="https://github.com/llvm/llvm-project/issues?q=is%3Aissue+is%3Aopen+label%3Anew-feature">for bugs with a "new-feature" keyword</a>.</li>
 </ol>
 
 </div>

--- a/OpenProjects.html
+++ b/OpenProjects.html
@@ -2013,7 +2013,7 @@ or to suggest other projects to add to this page.
 </p>
 
 <p>The projects in this page are open-ended. More specific projects are
-filed as unassigned enhancements in the <a href="https://bugs.llvm.org/">
+filed as unassigned enhancements in the <a href="https://github.com/llvm/llvm-project/issues/">
 LLVM bug tracker</a>. See the
 <a href="https://github.com/llvm/llvm-project/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee">list of currently outstanding issues</a>
 if you wish to help improve LLVM.</p>
@@ -2116,7 +2116,7 @@ across the board.</p>
 <div class="www_text">
 
 <p>
-The <a href="https://bugs.llvm.org/">LLVM bug tracker</a> occasionally
+The <a href="https://github.com/llvm/llvm-project/issues/">LLVM bug tracker</a> occasionally
 has <a href="https://github.com/llvm/llvm-project/labels/code-cleanup">"code-cleanup" bugs</a> filed in it.
 Taking one of these and fixing it is a good way to get your feet wet in the
 LLVM code and discover how some of its components work.  Some of these include
@@ -2203,7 +2203,7 @@ all the back-ends: CBE, llc, and lli.</p>
 href="/nightlytest/">test results</a> or on your own,
 where LLVM code generators do not produce optimal code or where another
 compiler produces better code.  Try to minimize the test case that demonstrates
-the issue.  Then, either <a href="https://bugs.llvm.org/">submit a
+the issue.  Then, either <a href="https://github.com/llvm/llvm-project/issues/">submit a
 bug</a> with your testcase and the code that LLVM produces vs. the code that it
 <em>should</em> produce, or even better, see if you can improve the code
 generator and submit a patch.  The basic idea is that it's generally quite easy

--- a/devmtg/2020-04/talks.html
+++ b/devmtg/2020-04/talks.html
@@ -1326,8 +1326,7 @@ ug_information_visual_analyzer.pdf">https://llvm.org/devmtg/2017-03/as
 sets/slides/diva_debug_information_visual_analyzer.pdf</a></p>
 <p>[2] <a href="https://www.prevanders.net/dwarf.html">https://www.pre
 vanders.net/dwarf.html</a></p>
-<p>[3] <a href="https://bugs.llvm.org/show_bug.cgi?id=43905">https://b
-ugs.llvm.org/show_bug.cgi?id=43905</a></p>
+<p>[3] <a href="https://llvm.org/PR43905">https://llvm.org/PR43905</a></p>
 </td></tr>
 <tr><td valign="top" id="LightningTalk_48">
 <b>Optimization Pass Sandboxing in LLVM: Replacing Heuristics on Statically Scheduled Targets</b>

--- a/header.incl
+++ b/header.incl
@@ -30,7 +30,7 @@
 <a href="/ProjectsWithLLVM/">LLVM&nbsp;Projects</a><br>
 <a href="/OpenProjects.html">Open&nbsp;Projects</a><br>
 <a href="/Users.html">LLVM&nbsp;Users</a><br>
-<a href="http://bugs.llvm.org/">Bug&nbsp;Database</a><br>
+<a href="https://bugs.llvm.org/">Bug&nbsp;tracker</a><br>
 <a href="/Logo.html">LLVM Logo</a><br>
 <a href="http://blog.llvm.org/">Blog</a><br>
 <a href="/devmtg/">Meetings</a><br>
@@ -98,7 +98,7 @@
   <a href="https://github.com/llvm/llvm-project/">Sources (GitHub)</a><br>
   <a href="https://reviews.llvm.org">Code Review</a><br>
   <a href="http://blog.llvm.org/">Blog</a><br>
-  <a href="http://bugs.llvm.org/">Bugzilla</a><br>
+  <a href="https://bugs.llvm.org/">Bug tracker</a><br>
   <a href="https://lab.llvm.org/buildbot/">Buildbot</a><br>
   <a href="http://green.lab.llvm.org/green/">Green Dragon</a><br>
   <a href="http://lnt.llvm.org/">LNT</a><br>

--- a/header.incl
+++ b/header.incl
@@ -30,7 +30,7 @@
 <a href="/ProjectsWithLLVM/">LLVM&nbsp;Projects</a><br>
 <a href="/OpenProjects.html">Open&nbsp;Projects</a><br>
 <a href="/Users.html">LLVM&nbsp;Users</a><br>
-<a href="https://bugs.llvm.org/">Bug&nbsp;tracker</a><br>
+<a href="https://github.com/llvm/llvm-project/issues/">Bug&nbsp;tracker</a><br>
 <a href="/Logo.html">LLVM Logo</a><br>
 <a href="http://blog.llvm.org/">Blog</a><br>
 <a href="/devmtg/">Meetings</a><br>
@@ -98,7 +98,7 @@
   <a href="https://github.com/llvm/llvm-project/">Sources (GitHub)</a><br>
   <a href="https://reviews.llvm.org">Code Review</a><br>
   <a href="http://blog.llvm.org/">Blog</a><br>
-  <a href="https://bugs.llvm.org/">Bug tracker</a><br>
+  <a href="https://github.com/llvm/llvm-project/issues/">Bug tracker</a><br>
   <a href="https://lab.llvm.org/buildbot/">Buildbot</a><br>
   <a href="http://green.lab.llvm.org/green/">Green Dragon</a><br>
   <a href="http://lnt.llvm.org/">LNT</a><br>


### PR DESCRIPTION
- Changes bug links to https://llvm.org/PRxxxx.
- Changes Bugzilla queries to GitHub queries.
- Use Bug tracker consistently, this replaces Bugzilla.
- Use https for bug links consistently.

Note https://bugs.llvm.org still points to Bugzilla instead of GitHub so
these links still don't work properly.