### PR TITLE
Fix <https://llvm.org/devmtg/2018-10/talk-abstracts.html#talk1>

### DIFF
--- a/devmtg/2018-10/talk-abstracts.html
+++ b/devmtg/2018-10/talk-abstracts.html
@@ -50,7 +50,7 @@ We also describe various papers which are being proposed to ISO C++ to move towa
 </ul>
     <b>Technical Talks</b>
 <ul>
-    <li><a id="#talk1">Lessons Learned Implementing Common Lisp with LLVM over Six Years</a> [ <a href="https://youtu.be/mbdXeRBbgDM"> Video</a> ] [ Slides ]
+    <li><a id="talk1">Lessons Learned Implementing Common Lisp with LLVM over Six Years</a> [ <a href="https://youtu.be/mbdXeRBbgDM"> Video</a> ] [ Slides ]
         <br><i>Christian Schafmeister</i>
         <p>
             I will present the lessons learned while using LLVM to efficiently implement a complex memory managed,


### PR DESCRIPTION
I found that <https://llvm.org/devmtg/2018-10/talk-abstracts.html#talk1> didn't take me to the expected anchor.  Problem is a superfluous `#`; see other `<a id="[...]">`.