### PR TITLE
[LLVM CGO] Fix a typo

### DIFF
--- a/devmtg/2022-04-03/index.html
+++ b/devmtg/2022-04-03/index.html
@@ -247,7 +247,7 @@ year.
         <td>
             <p>Arnamoy Bhattacharyya <br/>
                Peixin Qiao <br/>
-               Bryan Chen</p>
+               Bryan Chan</p>
         </td>
         <td>
             <p><a href="#tutorial-flang">[Tutorial] A walk through Flang OpenMP lowering: From FIR to LLVMIR</a>


### PR DESCRIPTION
My name was not spelled correctly in the CGO'22 workshop page.