### PR TITLE
SeasonOfDocs.html: Fix bad links

### DIFF
--- a/SeasonOfDocs.html
+++ b/SeasonOfDocs.html
@@ -43,10 +43,10 @@ If you have any questions, are interested in becoming a mentor, or project sugge
 
    <p><b>Related Material:</b>
    <ul>
-   <li><a href="http://llvm.org/docs/GettingStarted.html">Getting Started Guide</a>: Current document on llvm.org</li>
+   <li><a href="https://llvm.org/docs/GettingStarted.html">Getting Started Guide</a>: Current document on llvm.org</li>
    <li><a href="https://docs.google.com/document/d/1Prx1PLLU7VB0w2gBsAv0uB5MwX2Z7g9UIMTIUKZumcg/edit">Ideas from the workshop</a></li>
    <li><a href="https://docs.google.com/document/d/1sgnnwjU-ESvAQpQzeFY5l02OVllOlJbMm1E4YzylgC4/edit">Mockups and examples of new getting started guides</a></li>
-   <li>Various addendums to the main getting starting guide; <a href="http://llvm.org/docs/GettingStartedVS.html">Getting Started with the LLVM System using Microsoft Visual Studio</a>, <a href="http://llvm.org/docs/CMake.html">Building LLVM with CMake</a>, and many notes listed <a href="http://llvm.org/docs/">here</a>.
+   <li>Various addendums to the main getting starting guide; <a href="https://llvm.org/docs/GettingStartedVS.html">Getting Started with the LLVM System using Microsoft Visual Studio</a>, <a href="https://llvm.org/docs/CMake.html">Building LLVM with CMake</a>, and many notes listed <a href="https://llvm.org/docs/">here</a>.
    </p>
 </div>
 
@@ -58,13 +58,13 @@ If you have any questions, are interested in becoming a mentor, or project sugge
    <p><b>Description of the project:</b>
    LLVM is a large and constantly changing software project. There are really only a few papers and a book chapter that describe the system as a whole and give a good overview. We should develop more current documentation using Sphinx to document and describe the LLVM infrastructure.
    </p>
-   http://llvm.org/pubs/2002-12-LattnerMSThesis.html”Original
+
    <p><b>Related Material:</b>
    <ul>
-   <li>Most useful documentation - <a href=”http://www.aosabook.org/en/llvm.html”>a book chapter about LLVM</a></li>
-   <li><a href=”http://llvm.org/pubs/2008-10-04-ACAT-LLVM-Intro.html”>2008 presentation on LLVM</a></li>
-   <li><a href=”http://llvm.org/pubs/2004-01-30-CGO-LLVM.html”>2004 CGO Paper on LLVM</a></li>
-   <li><a href=”http://llvm.org/pubs/2002-12-LattnerMSThesis.html”>2002 Original thesis on LLVM</a></li>
+   <li>Most useful documentation - <a href="https://www.aosabook.org/en/llvm.html">a book chapter about LLVM</a></li>
+   <li><a href="https://llvm.org/pubs/2008-10-04-ACAT-LLVM-Intro.html">2008 presentation on LLVM</a></li>
+   <li><a href="https://llvm.org/pubs/2004-01-30-CGO-LLVM.html">2004 CGO Paper on LLVM</a></li>
+   <li><a href="https://llvm.org/pubs/2002-12-LattnerMSThesis.html">2002 Original thesis on LLVM</a></li>
 </ul>
  </p>
 </div>
@@ -80,8 +80,8 @@ If you have any questions, are interested in becoming a mentor, or project sugge
    
    <p><b>Related Material:</b>
   <ul>
-  <li><a href=”http://llvm.org/docs/”>Documentation Index</a></li>
-   <li><a href=”http://llvm.org/docs/SphinxQuickstartTemplate.html”>Sphinx Quickstart Guide</a></li>
+  <li><a href="https://llvm.org/docs/">Documentation Index</a></li>
+   <li><a href="https://llvm.org/docs/SphinxQuickstartTemplate.html">Sphinx Quickstart Guide</a></li>
 </ul>
 </p>
 </div>
@@ -97,8 +97,8 @@ If you have any questions, are interested in becoming a mentor, or project sugge
 
    <p><b>Related Material:</b>
    <ul>
-   <li><a href=”http://clang.llvm.org/index.html”>Clang main page</a></li>   
-   <li><a href=”http://clang.llvm.org/get_involved.html”>Getting Involved with Clang</a></li>
+   <li><a href="https://clang.llvm.org/index.html">Clang main page</a></li>
+   <li><a href="https://clang.llvm.org/get_involved.html">Getting Involved with Clang</a></li>
 </ul>
 </p>
 


### PR DESCRIPTION

* replace \xe2\x80\x9d (RIGHT DOUBLE QUOTATION MARK) with \x22 (QUOTATION MARK)
* use https for all links
* remove bad line 61 (partial duplicate of line 67)

Example, what a browser displays for a broken link:
https://llvm.org/%E2%80%9Dhttp://llvm.org/docs/%E2%80%9D

--
Regards ... Detlef