### PR TITLE
Update Green Dragon URL

### DIFF
--- a/header.incl
+++ b/header.incl
@@ -103,7 +103,7 @@
   <a href="http://blog.llvm.org/">Blog</a><br>
   <a href="https://github.com/llvm/llvm-project/issues/">Bug tracker</a><br>
   <a href="https://lab.llvm.org/buildbot/">Buildbot</a><br>
-  <a href="http://green.lab.llvm.org/green/">Green Dragon</a><br>
+  <a href="http://green.lab.llvm.org/">Green Dragon</a><br>
   <a href="http://lnt.llvm.org/">LNT</a><br>
   <a href="/reports/scan-build/">Scan-build</a><br>
   <a href="https://lab.llvm.org/coverage/coverage-reports/index.html">llvm-cov</a><br>


### PR DESCRIPTION
We recently updated the URL for Green Dragon from green.lab.llvm.org/green to green.lab.llvm.org.