### PR TITLE
Update Logo.html to clarify "old vs new" logo

### DIFF
--- a/Logo.html
+++ b/Logo.html
@@ -16,7 +16,7 @@ books</a> going back to 1977 which featured dragons on the cover.</p>
 <p>You can also download a larger version of <a href="img/LLVMWyvernBig.png">this image</a> here.</p>
 
 
-<div class="www_subsection">Older Dragon Logo</div>
+<div class="www_sectiontitle">Older Dragon Logo</div>
 
 <p>LLVM used an older dragon logo for many years.  This version is endearing
 for many reasons, including an unproven theory that it has its head upside 
@@ -46,7 +46,7 @@ suitable for use as icons etc.  These were contributed by Teresa Chang:</p>
 
 </div>
 
-<div class="www_subsection">Usage Rights</div>
+<div class="www_subsection">Usage Rights of the Older Logo</div>
 
 <div class="www_text">
 


### PR DESCRIPTION
The "Usage rights" at the bottom of the page apply to the older logo, not to the new one.  Clarify this by increasing the header size of "Older Dragon Logo" and making the subsection on usage more explicit.