### PR TITLE
Change link to RPM snapshots

### DIFF
--- a/header.incl
+++ b/header.incl
@@ -44,7 +44,7 @@
 <a href="https://releases.llvm.org/"><b>LLVM&nbsp;19.1.0</b></a><br>
 <a href="/releases/">All Releases</a><br>
 <a href="https://apt.llvm.org/">APT Packages</a><br>
-<a href="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots/">Fedora Snapshot Packages</a><br>
+<a href="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots/">RPM Snapshots</a><br>
 <a href="https://prereleases.llvm.org/">Pre-releases</a><br>
 <br>
 


### PR DESCRIPTION
We no longer just build daily snapshots of LLVM as RPMs for Fedora but also for RHEL operating systems. Therefore this link needed a more generic title.