### PR TITLE
[gsoc2025] Fix "Bfloat16 in LLVM libc" project link

### DIFF
--- a/OpenProjects.html
+++ b/OpenProjects.html
@@ -23,7 +23,7 @@
           </li>
           <li><a href="http://libc.llvm.org/"><b>LLVM libc</b></a>
             <ul>
-              <li><a href="bfloat16-libc">Bfloat16 in LLVM libc</a></li>
+              <li><a href="#bfloat16-libc">Bfloat16 in LLVM libc</a></li>
             </ul>
           </li>
           <li><a href="https://clangir.org"><b>ClangIR</b></a>


### PR DESCRIPTION
Fixes the link for the "Bfloat16 in LLVM libc" project in the open projects page. @lntue 