### PR TITLE
[GSoC 2026] Add backup mentor to incremental build-support for -fmodules-driver project

### DIFF
--- a/OpenProjects.html
+++ b/OpenProjects.html
@@ -629,8 +629,9 @@
     Medium
   </p>
 
-  <p><b>Mentors:</b>
-    <a href="https://github.com/naveen-seth">Naveen Hanig</a>
+  <p><b>Confirmed Mentors:</b>
+    <a href="https://github.com/naveen-seth">Naveen Hanig</a> (Primary Mentor),
+	<a href="https://github.com/Bigcheese">Michael Spencer</a> (Backup Mentor)
   </p>
 
    <p><b>Discourse:</b>


### PR DESCRIPTION
Adds @Bigcheese as backup-mentor for the project detailed in #161.